### PR TITLE
fix: 修复背景变黑和内存泄露

### DIFF
--- a/Assets/Scripts/BGManager.cs
+++ b/Assets/Scripts/BGManager.cs
@@ -53,8 +53,13 @@ public class BGManager : MonoBehaviour
 
     public void SetNewSpriteForVideo()
     {
-        videoTarget.GetComponent<SpriteRenderer>().sprite =
-                Sprite.Create(new Texture2D(480, 480), new Rect(0, 0, 480, 480), new Vector2(0.5f, 0.5f));
+        var sr = videoTarget.GetComponent<SpriteRenderer>();
+        if (sr.sprite != null)
+        {
+            Destroy(sr.sprite.texture);
+            Destroy(sr.sprite);
+        }
+        sr.sprite = Sprite.Create(new Texture2D(480, 480), new Rect(0, 0, 480, 480), new Vector2(0.5f, 0.5f));
     }
 
     public void SetIdleVideoFrameVisible(bool visible, string reason)

--- a/Assets/Scripts/Core/SimaiDataLoader.cs
+++ b/Assets/Scripts/Core/SimaiDataLoader.cs
@@ -44,20 +44,22 @@ public class SimaiDataLoader : MonoBehaviour
         if (path == string.Empty) {Debug.LogError("Empty path!"); yield break;}
         Debug.Log("Downloading maidata from " + path);
         SimaiProcess.ClearData();
-        UnityWebRequest www = UnityWebRequest.Get(path);
-        yield return www.SendWebRequest();
- 
-        if (www.result != UnityWebRequest.Result.Success) {
-            Debug.LogError("Error downloading data: " + www.error);
-        }
-        else
+        using (UnityWebRequest www = UnityWebRequest.Get(path))
         {
-            if (!SimaiProcess.ReadDataRaw(www.downloadHandler.text.Split('\n')))
-            {
-                Debug.LogError("Error Loading Chart.");
+            yield return www.SendWebRequest();
+
+            if (www.result != UnityWebRequest.Result.Success) {
+                Debug.LogError("Error downloading data: " + www.error);
             }
-            else {
-                callback.Invoke();
+            else
+            {
+                if (!SimaiProcess.ReadDataRaw(www.downloadHandler.text.Split('\n')))
+                {
+                    Debug.LogError("Error Loading Chart.");
+                }
+                else {
+                    callback.Invoke();
+                }
             }
         }
     }

--- a/Assets/Scripts/Core/SoundEffect.cs
+++ b/Assets/Scripts/Core/SoundEffect.cs
@@ -82,28 +82,35 @@ public class SoundEffect: MonoBehaviour
     {
         if (path == string.Empty) {Debug.LogError("Empty path!"); yield break;}
         Debug.Log("Downloading audio from " + path);
-        UnityWebRequest trackreq = UnityWebRequest.Get(path);
-        trackreq.downloadHandler = new DownloadHandlerAudioClip(path,AudioType.MPEG);
-        trackreq.SendWebRequest();
-        while (!trackreq.isDone) {
-            callback.Invoke(trackreq.downloadProgress);
-            yield return new WaitForSecondsRealtime(0.1f);
-        }
-        if (trackreq.result != UnityWebRequest.Result.Success)
+        if (bgmStream.clip != null)
         {
-            Debug.LogError("Error downloading audio: " + trackreq.error);
+            Destroy(bgmStream.clip);
+            bgmStream.clip = null;
         }
-        else
+        using (UnityWebRequest trackreq = UnityWebRequest.Get(path))
         {
-            var clip = DownloadHandlerAudioClip.GetContent(trackreq);
-            if (clip != null)
-            {
-                bgmStream.clip = clip;
-                bgmStream.clip.LoadAudioData();
-                if (successcallback != null)
-                    successcallback.Invoke();
+            trackreq.downloadHandler = new DownloadHandlerAudioClip(path,AudioType.MPEG);
+            trackreq.SendWebRequest();
+            while (!trackreq.isDone) {
+                callback.Invoke(trackreq.downloadProgress);
+                yield return new WaitForSecondsRealtime(0.1f);
             }
-            else { Debug.LogError("AudioClip is null!"); }
+            if (trackreq.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError("Error downloading audio: " + trackreq.error);
+            }
+            else
+            {
+                var clip = DownloadHandlerAudioClip.GetContent(trackreq);
+                if (clip != null)
+                {
+                    bgmStream.clip = clip;
+                    bgmStream.clip.LoadAudioData();
+                    if (successcallback != null)
+                        successcallback.Invoke();
+                }
+                else { Debug.LogError("AudioClip is null!"); }
+            }
         }
         
     }

--- a/Assets/Scripts/GameMainManager.cs
+++ b/Assets/Scripts/GameMainManager.cs
@@ -176,6 +176,8 @@ public class GameMainManager : MonoBehaviour
         var hasVideo = !string.IsNullOrWhiteSpace(videopath);
         if (hasVideo)
         {
+            bgManager.videoPlayer.Stop();
+            bgManager.SetNewSpriteForVideo();
             bgManager.videoPlayer.url = videopath;
         }
         else

--- a/Assets/Scripts/WebLoader.cs
+++ b/Assets/Scripts/WebLoader.cs
@@ -15,28 +15,36 @@ namespace API
         public static IEnumerator LoadBGFromWeb(string path, Action callback)
         {
             if (path == string.Empty) { Debug.LogError("empty bg path!"); yield break; }
-            UnityWebRequest bgreq = UnityWebRequest.Get(path);
-            bgreq.downloadHandler = new DownloadHandlerTexture();
-            yield return bgreq.SendWebRequest();
-            if (bgreq.result != UnityWebRequest.Result.Success)
+            if (BGManager.spriteRender != null && BGManager.spriteRender.sprite != null)
             {
-                Debug.LogError("Error downloading bg: " + bgreq.error + bgreq.downloadHandler.error);
-                callback.Invoke();
+                var oldTex = BGManager.spriteRender.sprite.texture;
+                UnityEngine.Object.Destroy(BGManager.spriteRender.sprite);
+                if (oldTex != null) UnityEngine.Object.Destroy(oldTex);
+                BGManager.spriteRender.sprite = null;
             }
-            else
+            using (UnityWebRequest bgreq = UnityWebRequest.Get(path))
             {
-                var texture = DownloadHandlerTexture.GetContent(bgreq);
-                var sprite = Sprite.Create(
-                    texture,
-                    new Rect(0.0f, 0.0f, texture.width, texture.height),
-                    new Vector2(0.5f, 0.5f));
+                bgreq.downloadHandler = new DownloadHandlerTexture();
+                yield return bgreq.SendWebRequest();
+                if (bgreq.result != UnityWebRequest.Result.Success)
+                {
+                    Debug.LogError("Error downloading bg: " + bgreq.error + bgreq.downloadHandler.error);
+                    callback.Invoke();
+                }
+                else
+                {
+                    var texture = DownloadHandlerTexture.GetContent(bgreq);
+                    var sprite = Sprite.Create(
+                        texture,
+                        new Rect(0.0f, 0.0f, texture.width, texture.height),
+                        new Vector2(0.5f, 0.5f));
 
-                BGManager.spriteRender.sprite = sprite;
-                var scale = 1080f / (float)sprite.texture.width;
-                BGManager.spriteRender.transform.localScale = new Vector3(scale, scale, scale);
-                callback.Invoke();
+                    BGManager.spriteRender.sprite = sprite;
+                    var scale = 1080f / (float)sprite.texture.width;
+                    BGManager.spriteRender.transform.localScale = new Vector3(scale, scale, scale);
+                    callback.Invoke();
+                }
             }
-
         }
 
     }


### PR DESCRIPTION
Belike: ~~多点十几次就有~~
<img width="579" height="130" alt="image" src="https://github.com/user-attachments/assets/882d768f-70f8-446d-b2cd-14b29823e136" />


- 切换视频前先停止播放并重置 Sprite，修复 #5
- 多处资源替换前主动销毁旧纹理/音频/ Sprite，避免内存泄漏
- 将 `UnityWebRequest` 改为 `using` 语法，确保正确释放

<img width="480" height="611" alt="fix-1" src="https://github.com/user-attachments/assets/2e0c544f-967f-4ddf-934e-642e6efeeeb8" />
